### PR TITLE
Add IndexedDB storage and new recipe page

### DIFF
--- a/add.html
+++ b/add.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Add Recipe</title>
+</head>
+<body>
+  <h1>Add Recipe</h1>
+  <form id="recipe-form">
+    <label>Name <input id="name" required></label><br>
+    <label>Type <input id="type" required></label><br>
+    <button type="submit">Save</button>
+  </form>
+  <script src="db.js"></script>
+  <script>
+    document.getElementById('recipe-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const name = document.getElementById('name').value.trim();
+      const type = document.getElementById('type').value.trim();
+      if (name && type) {
+        await addRecipe({ name, type });
+        window.location.href = 'index.html';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/db.js
+++ b/db.js
@@ -1,0 +1,56 @@
+const DB_NAME = 'recipes-db';
+const STORE_NAME = 'recipes';
+const DB_VERSION = 1;
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = event => {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function getRecipes() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function addRecipe(recipe) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.add(recipe);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function seedRecipes(recipes) {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  for (const r of recipes) {
+    store.add(r);
+  }
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { openDB, getRecipes, addRecipe, seedRecipes };
+}

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 </head>
 <body>
   <h1>Welcome to My PWA</h1>
+  <button id="add-button">Add Recipe</button>
   <ul id="recipe-list"></ul>
   <script>
     if ('serviceWorker' in navigator) {
@@ -40,18 +41,35 @@
     }
   </script>
   <script src="recipes.js"></script>
+  <script src="db.js"></script>
   <script>
-    const list = document.getElementById('recipe-list');
-    if (window.recipes && Array.isArray(window.recipes)) {
-      window.recipes.forEach(r => {
+    async function renderRecipes() {
+      const list = document.getElementById('recipe-list');
+      list.innerHTML = '';
+      let items = await getRecipes();
+      if (items.length === 0 && window.recipes) {
+        await seedRecipes(window.recipes);
+        items = await getRecipes();
+      }
+      items.forEach(r => {
+        let icon = r.icon;
+        if (!icon) {
+          icon = r.type && r.type.toLowerCase().includes('mead') ? '🍯' : '🥃';
+        }
         const li = document.createElement('li');
         li.className = 'recipe-item';
-        li.innerHTML = `<span class="icon">${r.icon}</span>` +
+        li.innerHTML = `<span class="icon">${icon}</span>` +
           `<span class="name">${r.name}</span> - ` +
           `<span class="type">${r.type}</span>`;
         list.appendChild(li);
       });
     }
+
+    document.getElementById('add-button').addEventListener('click', () => {
+      window.location.href = 'add.html';
+    });
+
+    renderRecipes();
   </script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,7 +2,10 @@ const CACHE_NAME = 'pwa-cache-v1';
 const ASSETS = [
   '/',
   '/index.html',
-  '/manifest.json'
+  '/add.html',
+  '/manifest.json',
+  '/db.js',
+  '/recipes.js'
 ];
 self.addEventListener('install', event => {
   event.waitUntil(


### PR DESCRIPTION
## Summary
- provide a small IndexedDB helper (`db.js`)
- load recipes from IndexedDB and add an Add Recipe button
- add page to create new recipes
- cache new files in service worker

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685354ddeaf08331bff0e55dc260a4ed